### PR TITLE
Fix installation on python 3, add -h flag

### DIFF
--- a/bin/duc
+++ b/bin/duc
@@ -17,16 +17,32 @@ def duc(path):
     return get_size(path)
 
 
+def _format_human_readable_size(num_bytes):
+    units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == 'Y':
+            if unit == 'B':
+                return '%dB' % num_bytes
+            return '%.1f%s' % (size, unit)
+        size = size / 1024.0
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' %
                     disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str,
                         help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true',
                         help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', dest='human', action='store_true',
+                        help='Print human readable sizes (e.g. 1.1K, 234M).')
+    parser.add_argument('--help', action='help',
+                        help='Show this help message and exit.')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -39,4 +55,7 @@ if __name__ == '__main__':
         exit()
 
     size = duc(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        print('%s\t%s' % (_format_human_readable_size(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "disktools"
+version = "0.0.3"
+description = "Extensions to basic disk tools like du, df, etc, but written in python"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [
+  { name = "Yauhen Yakimovich", email = "eugeny.yakimovitch@gmail.com" }
+]
+requires-python = ">=3.8"
+dependencies = [
+  "bson>=0.3.3"
+]
+
+[project.urls]
+Homepage = "https://github.com/ewiger/disktools"
+Repository = "https://github.com/ewiger/disktools"
+
+[project.scripts]
+duc = "disktools.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["disktools*"]
+
+[project.optional-dependencies]
+test = [
+  "sh"
+]
+

--- a/src/disktools/cli.py
+++ b/src/disktools/cli.py
@@ -6,13 +6,29 @@ from disktools import __version__ as disktools_version
 from disktools.disk_usage import get_size, purge_rec_cache
 
 
+def _format_human_readable_size(num_bytes):
+    units = ['B', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+    size = float(num_bytes)
+    for unit in units:
+        if size < 1024.0 or unit == 'Y':
+            if unit == 'B':
+                return '%dB' % num_bytes
+            return '%.1f%s' % (size, unit)
+        size = size / 1024.0
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog='duc',
         description='Disk Usage (Cached) [disktools ver. %s]' % disktools_version,
+        add_help=False,
     )
     parser.add_argument('path', type=str, help='Get size of specified path.')
     parser.add_argument('--purge', action='store_true', help='Purge and remove all the cache.')
+    parser.add_argument('-h', '--human', dest='human', action='store_true',
+                        help='Print human readable sizes (e.g. 1.1K, 234M).')
+    parser.add_argument('--help', action='help',
+                        help='Show this help message and exit.')
     args = parser.parse_args()
 
     if not os.path.exists(args.path):
@@ -24,7 +40,10 @@ def main() -> None:
         return
 
     size = get_size(args.path)
-    print('%d\t%s' % (size, args.path))
+    if args.human:
+        print('%s\t%s' % (_format_human_readable_size(size), args.path))
+    else:
+        print('%d\t%s' % (size, args.path))
 
 
 if __name__ == '__main__':

--- a/src/disktools/cli.py
+++ b/src/disktools/cli.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals, print_function
+import os
+import sys
+import argparse
+from disktools import __version__ as disktools_version
+from disktools.disk_usage import get_size, purge_rec_cache
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog='duc',
+        description='Disk Usage (Cached) [disktools ver. %s]' % disktools_version,
+    )
+    parser.add_argument('path', type=str, help='Get size of specified path.')
+    parser.add_argument('--purge', action='store_true', help='Purge and remove all the cache.')
+    args = parser.parse_args()
+
+    if not os.path.exists(args.path):
+        sys.stderr.write('Path was not found: %s' % args.path)
+        sys.exit(1)
+
+    if args.purge is True:
+        purge_rec_cache(args.path)
+        return
+
+    size = get_size(args.path)
+    print('%d\t%s' % (size, args.path))
+
+
+if __name__ == '__main__':
+    main()
+

--- a/tests/test_diskusage.py
+++ b/tests/test_diskusage.py
@@ -20,7 +20,7 @@ from disktools.disk_usage import get_size
 
 def write_blob(filename, size=None):
     size = random.randint(1, 1000000)
-    with open(filename, 'w+') as output:
+    with open(filename, 'wb+') as output:
         output.write(bytearray(os.urandom(size)))
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,80 @@
+version = 1
+revision = 3
+requires-python = ">=3.8"
+resolution-markers = [
+    "python_full_version >= '3.8.1'",
+    "python_full_version < '3.8.1'",
+]
+
+[[package]]
+name = "bson"
+version = "0.5.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/53/7c534a38850f2252275d7f949aed2219095e90df1e2d180a9c8ed139e499/bson-0.5.10.tar.gz", hash = "sha256:d6511b2ab051139a9123c184de1a04227262173ad593429d21e443d6462d6590", size = 10363, upload-time = "2020-05-26T11:13:47.979Z" }
+
+[[package]]
+name = "disktools"
+version = "0.0.3"
+source = { editable = "." }
+dependencies = [
+    { name = "bson" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "sh", version = "1.14.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.8.1'" },
+    { name = "sh", version = "2.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.8.1'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bson", specifier = ">=0.3.3" },
+    { name = "sh", marker = "extra == 'test'" },
+]
+provides-extras = ["test"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "sh"
+version = "1.14.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/09/89c28aaf2a49f226fef8587c90c6386bd2cc03a0295bc4ff7fc6ee43c01d/sh-1.14.3.tar.gz", hash = "sha256:e4045b6c732d9ce75d571c79f5ac2234edd9ae4f5fa9d59b09705082bdca18c7", size = 62851, upload-time = "2022-07-18T07:17:50.947Z" }
+
+[[package]]
+name = "sh"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.8.1'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/52/f43920223c93e31874677c681b8603d36a40d3d8502d3a37f80d3995d43e/sh-2.2.2.tar.gz", hash = "sha256:653227a7c41a284ec5302173fbc044ee817c7bad5e6e4d8d55741b9aeb9eb65b", size = 345866, upload-time = "2025-02-24T07:16:25.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/98/d82f14ac7ffedbd38dfa2383f142b26d18d23ca6cf35a40f4af60df666bd/sh-2.2.2-py3-none-any.whl", hash = "sha256:e0b15b4ae8ffcd399bc8ffddcbd770a43c7a70a24b16773fbb34c001ad5d52af", size = 38295, upload-time = "2025-02-24T07:16:23.782Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]


### PR DESCRIPTION
not sure if you want to update this after 11 years, but it helped me and i think contributing upstream never hurts 
- you can now install it on python 3 (it has pyproject.toml and there was an error where 'reload' doesnt exist otherwise)
- the flag -h prints the size in human-readable format